### PR TITLE
feat(auth): replace hardcoded authorization strings with constants

### DIFF
--- a/src/api/Family.Api/GraphQL/Queries/UserQueries.cs
+++ b/src/api/Family.Api/GraphQL/Queries/UserQueries.cs
@@ -1,3 +1,4 @@
+using Family.Api.Authorization;
 using Family.Api.Data;
 using Family.Api.Models;
 using HotChocolate.Authorization;
@@ -34,7 +35,7 @@ public class UserQueries
         CancellationToken cancellationToken)
     {
         var currentUserSubId = claimsPrincipal.FindFirst("sub")?.Value;
-        var isAdmin = claimsPrincipal.HasClaim("family_roles", "family-admin");
+        var isAdmin = claimsPrincipal.HasClaim(Claims.FamilyRoles, Roles.FamilyAdmin);
 
         // Users can only see their own profile unless they are admin
         if (!isAdmin)

--- a/src/api/Family.Api/Services/CachedKeycloakService.cs
+++ b/src/api/Family.Api/Services/CachedKeycloakService.cs
@@ -1,3 +1,4 @@
+using Family.Api.Authorization;
 using Family.Api.Data;
 using Family.Api.Models;
 using Family.Infrastructure.Caching.Abstractions;
@@ -416,7 +417,7 @@ public class CachedKeycloakService : IKeycloakService
     private async Task SyncUserRolesAsync(User user, JwtSecurityToken jsonToken)
     {
         var familyRoles = jsonToken.Claims
-            .Where(c => c.Type == "family_roles")
+            .Where(c => c.Type == Claims.FamilyRoles)
             .Select(c => c.Value)
             .ToList();
 

--- a/src/api/Family.Api/Services/KeycloakService.cs
+++ b/src/api/Family.Api/Services/KeycloakService.cs
@@ -1,3 +1,4 @@
+using Family.Api.Authorization;
 using Family.Api.Data;
 using Family.Api.Models;
 using Microsoft.EntityFrameworkCore;
@@ -301,7 +302,7 @@ public class KeycloakService : IKeycloakService
     private async Task SyncUserRolesAsync(User user, JwtSecurityToken jsonToken)
     {
         var familyRoles = jsonToken.Claims
-            .Where(c => c.Type == "family_roles")
+            .Where(c => c.Type == Claims.FamilyRoles)
             .Select(c => c.Value)
             .ToList();
 


### PR DESCRIPTION
## Summary
- Replaced all hardcoded authorization strings with constants from the Authorization namespace
- Updated UserQueries.cs to use Claims.FamilyRoles and Roles.FamilyAdmin constants  
- Updated KeycloakService.cs and CachedKeycloakService.cs to use Claims.FamilyRoles constant
- Improved maintainability and consistency of authorization code across the API
- Authorization constants were already well-tested with comprehensive unit tests

## Changes Made
- ✅ UserQueries.cs: Replaced `"family_roles"` and `"family-admin"` with constants
- ✅ KeycloakService.cs: Replaced `"family_roles"` with Claims.FamilyRoles constant
- ✅ CachedKeycloakService.cs: Replaced `"family_roles"` with Claims.FamilyRoles constant
- ✅ Added proper Authorization namespace imports to all modified files

## Test Plan
- ✅ All existing unit tests pass (85/85)
- ✅ Authorization constants have comprehensive test coverage
- ✅ Code coverage remains above 40% threshold (46.7%)
- ✅ Build succeeds without errors
- ✅ No breaking changes to existing functionality

## Benefits
- Eliminates risk of typos in authorization role/claim strings
- Centralizes authorization constants for easier maintenance
- Improves code consistency across the application
- Better IntelliSense support and refactoring capabilities

Fixes #64

🤖 Generated with [Claude Code](https://claude.ai/code)